### PR TITLE
Add current failed tasks metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.3.3
+
+- Add 'airflow_current_failed_tasks' metric
 ## 1.3.2
 
 - Remove 'hostname' from airflow_task_status by @cansjt see https://github.com/epoch8/airflow-exporter/issues/77 for details

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Labels:
 Value: duration in seconds of the longest DAG Run for given DAG. This metric 
 is not available for DAGs that have already completed.
 
+### `airflow_current_failed_tasks`
+
+Labels:
+
+* `dag_id`
+* `task_id`
+* `execution_date`
+
+Value: 1 if the current tasks in the failed status.
 ## License
 
 Distributed under the BSD license. See [LICENSE](LICENSE) for more

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=["airflow_exporter"],
     setup_requires=['setuptools_scm'],
     install_requires=[
-        "apache-airflow>=1.10.3",
+        "apache-airflow<=1.10.15",
         "prometheus_client>=0.4.2",
     ],
     entry_points={


### PR DESCRIPTION
Add a new metric to the exporter `airflow_current_failed_tasks`. 

Notes:
* This exposes all failed tasks. This status is removed only when a more recent task is with the `success` status. This will give the possibility to add resolution to the Grafana Alerts.  

* It exposes the dag_id, task_is and, the execution date. The `execution date` will be interesting to retrieve the task log URL which will be added to the Alert/Message.  

* The Grafana alerts will be airflow_current_failed_tasks > 0. When Airflow or Grafana will be restarted only the current failed tasks will be sent again to Slack. 

Exemple: 
![image](https://user-images.githubusercontent.com/20433878/148094013-ca0e82fa-d2b8-43c0-b69b-bc874be64a44.png)

![image](https://user-images.githubusercontent.com/20433878/148093961-021424bb-1bb3-4b53-87c9-32c6dc7b141c.png)

![image](https://user-images.githubusercontent.com/20433878/148094333-4529770d-a605-46a1-99fa-ba1cbc746058.png)
Nothing in the exporter!

